### PR TITLE
change copying of 3d point array to match surrounding code

### DIFF
--- a/Kinect2Server/Kinect2ServerService.cs
+++ b/Kinect2Server/Kinect2ServerService.cs
@@ -30,7 +30,6 @@ using System.ServiceProcess;
 using System.Windows.Media;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using System.IO;
 
 namespace PersonalRobotics.Kinect2Server
 {


### PR DESCRIPTION
Looking at the rest of the code in k2_server, they appear to use Stream.Buffer.BlockCopy to copy the raw bytes from a data structure. Add some (untested) code which apes this idiom. I'd be interested to know if this works. If so, it's probably more likely to be accepted upstream.
